### PR TITLE
Throw a 404 exception when item was not found in database

### DIFF
--- a/classes/PHPixie/ORM.php
+++ b/classes/PHPixie/ORM.php
@@ -49,6 +49,8 @@ class ORM {
 		{
 			$model = $model->where($model->id_field, $id)->find();
 			$model->values(array($model->id_field => $id));
+			if (!$model->loaded())
+				throw new \PHPixie\Exception\PageNotFound(ucfirst($model->model_name)." not found with id '".$id."'");
 		}
 		return $model;
 	}


### PR DESCRIPTION
The idea is to avoid repetitive conditions on CRUD actions when item was not found in the database when using : 

```php
$user = $this->pixie->orm->get('user', $id);
```