### PR TITLE
Don't selecting inserted/updated row, if database can return it at once.

### DIFF
--- a/classes/PHPixie/ORM/Model.php
+++ b/classes/PHPixie/ORM/Model.php
@@ -769,7 +769,7 @@ class Model
 		if ($row && isset($row[$this->id_field])) {
 			$this->_row[$this->id_field] = $row[$this->id_field];
 		}
-		if ($this->loaded() || $this->_row[$this->id_field])
+		if ($this->loaded() || (isset($this->_row[$this->id_field])&&$this->_row[$this->id_field]))
 		{
 			$id = $this->_row[$this->id_field];
 		}


### PR DESCRIPTION
Trying to avoid unnecessary database requests, if database can return inserted/updated row at once.
Don't calling insert_id() if id is already known, which allows using not sequence-based ids.
