### PR TITLE
Get Other Repositories from Wrappers Repository

### DIFF
--- a/src/PHPixie/ORM/Models/Type/Database/Implementation/Repository.php
+++ b/src/PHPixie/ORM/Models/Type/Database/Implementation/Repository.php
@@ -31,7 +31,12 @@ abstract class Repository implements \PHPixie\ORM\Models\Type\Database\Repositor
     {
         return $this->config->model;
     }
-    
+
+    public function databaseModel()
+    {
+        return $this->databaseModel;
+    }
+
     public function query()
     {
         return $this->databaseModel->query($this->modelName());

--- a/src/PHPixie/ORM/Models/Type/Database/Repository.php
+++ b/src/PHPixie/ORM/Models/Type/Database/Repository.php
@@ -10,6 +10,7 @@ interface Repository
     public function delete($entity);
     public function load($data);
     public function create();
+    public function databaseModel();
 
     /**
      * @return Query

--- a/src/PHPixie/ORM/Wrappers/Type/Database/Repository.php
+++ b/src/PHPixie/ORM/Wrappers/Type/Database/Repository.php
@@ -13,7 +13,12 @@ class Repository implements \PHPixie\ORM\Models\Type\Database\Repository
     {
         $this->repository = $repository;
     }
-    
+
+    public function databaseModel()
+    {
+        return $this->repository->databaseModel();
+    }
+
     public function config()
     {
         return $this->repository->config();


### PR DESCRIPTION
Очень не хватает возможности получить репозиторий из другого репозитория.
Этой возможности можно добиться, если получить доступ к переменной  $databaseModel
Теперь можно внутри репозитория оперировать данными других моделей.

Такой подход очень удобен, если репозиторий передается в конструктор какого-нибудь класса (В таком случае не нужно так же тащить в конструктор и сам класс ORM)
```
$repositoryArticle = $orm->repository('article');
$articles = $repositoryArticle->findForUsers();

// class Project\App\ORMWrappers\ArticleRepository
public function findForUsers($preload = array()){
    $repositorySettings = $this->databaseModel()->repository('settings');
    $settingsEntity = $repositorySettings->query()->in(1)->findOne();
    $query = $this->query();
    if($settingsEntity && $settingsEntity->showOnlyAuthor){
        $query->whereNot('userId', null);
    }
    $query->find($preload);
}
```