### PR TITLE
Fix use PHPixie\Database\Type\SQL\Expression in where in Query

### DIFF
--- a/src/PHPixie/ORM/Conditions/Builder/Container.php
+++ b/src/PHPixie/ORM/Conditions/Builder/Container.php
@@ -21,10 +21,11 @@ class Container extends \PHPixie\Database\Conditions\Builder\Container
     public function addOperatorCondition($logic, $negate, $field, $operator, $values)
     {
         $relationship = null;
-        
-        if (($pos = strpos($field, '>')) !== false || ($pos = strrpos($field, '.')) !== false) {
-            $relationship = substr($field, 0, $pos);
-            $field = substr($field, $pos + 1);
+        if(is_string($field)) {
+            if(($pos = strpos($field, '>')) !== false || ($pos = strrpos($field, '.')) !== false) {
+                $relationship = substr($field, 0, $pos);
+                $field        = substr($field, $pos + 1);
+            }
         }
 
         $condition = $this->buildOperatorCondition($field, $operator, $values);


### PR DESCRIPTION
Example: $query->where(new Expression("REPLACE(SUBSTRING(SUBSTRING_INDEX(`name`, '-', 1), LENGTH(SUBSTRING_INDEX(`name`, '-', 0)) + 1), '-', '')"), '<=', '64');