### PR TITLE
Fix the lost options for preloaders of the form xxx.xxx...

### DIFF
--- a/src/PHPixie/ORM/Values/Preload.php
+++ b/src/PHPixie/ORM/Values/Preload.php
@@ -47,7 +47,7 @@ class Preload
         }
         
         if(!empty($explodedPath))
-            $property->preload()->addExplodedPath($explodedPath);
+            $property->preload()->addExplodedPath($explodedPath, $options);
         
         return $this;
     }


### PR DESCRIPTION
If the preloader was in the form of a path, options were not passed